### PR TITLE
Flex package.json engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "validate": "npm ls"
   },
   "engines": {
-    "node": "6.X.X",
-    "npm": "3.X.X"
+    "node": ">=6.X.X",
+    "npm": ">=3.X.X"
   },
   "author": "John Griffing",
   "license": "MIT",


### PR DESCRIPTION
Although npm seems less strict by default, yarn complains when installing this package with a newer version of node. I assume you meant to express minimum versions, rather than exact versions? (note I have not tested this change, but just following the version syntax in [the package.json docs](https://docs.npmjs.com/files/package.json#engines))

Thanks for writing this small piece of magic. :)